### PR TITLE
fix: declare the variable before using it

### DIFF
--- a/DockerInstallation.sh
+++ b/DockerInstallation.sh
@@ -983,6 +983,7 @@ function configure_docker_ce_mirror() {
             if [[ "${SYSTEM_JUDGMENT}" == "${SYSTEM_FEDORA}" ]]; then
                 dnf-3 config-manager -y --add-repo "${repo_file_url}"
             else
+                local package_manager="$(get_package_manager)"
                 if [[ "${package_manager}" == "dnf" ]]; then
                     dnf config-manager -y --add-repo "${repo_file_url}"
                 else


### PR DESCRIPTION
I have been using this script to install Docker on my PC and encountered a bug.

I tested the fix on the system below, and it works correctly now.

This PR contains only a single-line change, making it easy to review.
Please consider merging it.

<img width="2258" height="1082" alt="image" src="https://github.com/user-attachments/assets/9c9d003e-8ecb-44c3-ac44-21ea3790ad18" />
