### PR TITLE
fix(mirrors): 更新腾讯镜像站IPv6支持状态

### DIFF
--- a/docs/assets/js/components/mirrors-table/data.js
+++ b/docs/assets/js/components/mirrors-table/data.js
@@ -41,7 +41,7 @@ const mirrorsTableData = [
         iconStyle: { verticalAlign: '-0.25em' },
         url: 'https://mirrors.tencent.com',
         domain: 'mirrors.tencent.com',
-        ipv6: false,
+        ipv6: true,
         debian: true,
         ubuntu: true,
         centos_vault: true,


### PR DESCRIPTION
- 将腾讯镜像站的ipv6属性从false修改为true
- 确保镜像表数据准确反映腾讯镜像站的IPv6支持情况