### PR TITLE
fix(mirrors): update National Yang Ming Chiao Tung University mirror URL

### DIFF
--- a/ChangeMirrors.sh
+++ b/ChangeMirrors.sh
@@ -76,7 +76,7 @@ mirror_list_abroad=(
     "mirrors.xtom.sg"
     "free.nchc.org.tw"
     "mirror.ossplanet.net"
-    "linux.cs.nctu.edu.tw"
+    "linux.cs.nycu.edu.tw"
     "ftp.tku.edu.tw"
     "mirror.twds.com.tw"
     "mirror.anigil.com"

--- a/docs/mirrors/index.en.md
+++ b/docs/mirrors/index.en.md
@@ -68,7 +68,7 @@ search:
     | AS · xTom · Singapore :flag-SG: | [mirrors.xtom.sg](https://mirrors.xtom.sg "https://mirrors.xtom.sg") |
     | AS · NCHC Free Software Lab · Taiwan :flag-TW: | [free.nchc.org.tw](https://free.nchc.org.tw "https://free.nchc.org.tw") |
     | AS · OSS Planet · Taiwan :flag-TW: | [mirror.ossplanet.net](https://mirror.ossplanet.net "https://mirror.ossplanet.net") |
-    | AS · National Yang Ming Chiao Tung University · Taiwan :flag-TW: | [linux.cs.nctu.edu.tw](https://linux.cs.nctu.edu.tw "https://linux.cs.nctu.edu.tw") |
+    | AS · National Yang Ming Chiao Tung University · Taiwan :flag-TW: | [linux.cs.nycu.edu.tw](https://linux.cs.nycu.edu.tw "https://linux.cs.nycu.edu.tw") |
     | AS · Tamkang University · Taiwan :flag-TW: | [ftp.tku.edu.tw](https://ftp.tku.edu.tw "https://ftp.tku.edu.tw") |
     | AS · Taiwan Digital Streaming · Taiwan :flag-TW: | [mirror.twds.com.tw](https://mirror.twds.com.tw "https://mirror.twds.com.tw") |
     | AS · AniGil Linux Archive · Korea :flag-KR: | [mirror.anigil.com](https://mirror.anigil.com "https://mirror.anigil.com") |
@@ -166,7 +166,7 @@ search:
     | AS · xTom · Singapore :flag-SG: | [mirrors.xtom.sg](https://mirrors.xtom.sg "https://mirrors.xtom.sg") |
     | AS · NCHC Free Software Lab · Taiwan :flag-TW: | [free.nchc.org.tw](https://free.nchc.org.tw "https://free.nchc.org.tw") |
     | AS · OSS Planet · Taiwan :flag-TW: | [mirror.ossplanet.net](https://mirror.ossplanet.net "https://mirror.ossplanet.net") |
-    | AS · National Yang Ming Chiao Tung University · Taiwan :flag-TW: | [linux.cs.nctu.edu.tw](https://linux.cs.nctu.edu.tw "https://linux.cs.nctu.edu.tw") |
+    | AS · National Yang Ming Chiao Tung University · Taiwan :flag-TW: | [linux.cs.nycu.edu.tw](https://linux.cs.nycu.edu.tw "https://linux.cs.nycu.edu.tw") |
     | AS · Tamkang University · Taiwan :flag-TW: | [ftp.tku.edu.tw](https://ftp.tku.edu.tw "https://ftp.tku.edu.tw") |
     | AS · Taiwan Digital Streaming · Taiwan :flag-TW: | [mirror.twds.com.tw](https://mirror.twds.com.tw "https://mirror.twds.com.tw") |
     | AS · AniGil Linux Archive · Korea :flag-KR: | [mirror.anigil.com](https://mirror.anigil.com "https://mirror.anigil.com") |

--- a/docs/mirrors/index.md
+++ b/docs/mirrors/index.md
@@ -68,7 +68,7 @@ search:
     | 亚洲 · xTom · 新加坡 :flag-SG: | [mirrors.xtom.sg](https://mirrors.xtom.sg "https://mirrors.xtom.sg") |
     | 亚洲 · 自由软件实验室(NCHC) · 台湾 :flag-TW: | [free.nchc.org.tw](https://free.nchc.org.tw "https://free.nchc.org.tw") |
     | 亚洲 · OSS Planet · 台湾 :flag-TW: | [mirror.ossplanet.net](https://mirror.ossplanet.net "https://mirror.ossplanet.net") |
-    | 亚洲 · 国立阳明交通大学 · 台湾 :flag-TW: | [linux.cs.nctu.edu.tw](https://linux.cs.nctu.edu.tw "https://linux.cs.nctu.edu.tw") |
+    | 亚洲 · 国立阳明交通大学 · 台湾 :flag-TW: | [linux.cs.nycu.edu.tw](https://linux.cs.nycu.edu.tw "https://linux.cs.nycu.edu.tw") |
     | 亚洲 · 淡江大学 · 台湾 :flag-TW: | [ftp.tku.edu.tw](https://ftp.tku.edu.tw "https://ftp.tku.edu.tw") |
     | 亚洲 · Taiwan Digital Streaming · 台湾 :flag-TW: | [mirror.twds.com.tw](https://mirror.twds.com.tw "https://mirror.twds.com.tw") |
     | 亚洲 · AniGil Linux Archive · 韩国 :flag-KR: | [mirror.anigil.com](https://mirror.anigil.com "https://mirror.anigil.com") |
@@ -166,7 +166,7 @@ search:
     | 亚洲 · xTom · 新加坡 :flag-SG: | [mirrors.xtom.sg](https://mirrors.xtom.sg "https://mirrors.xtom.sg") |
     | 亚洲 · 自由软件实验室(NCHC) · 台湾 :flag-TW: | [free.nchc.org.tw](https://free.nchc.org.tw "https://free.nchc.org.tw") |
     | 亚洲 · OSS Planet · 台湾 :flag-TW: | [mirror.ossplanet.net](https://mirror.ossplanet.net "https://mirror.ossplanet.net") |
-    | 亚洲 · 国立阳明交通大学 · 台湾 :flag-TW: | [linux.cs.nctu.edu.tw](https://linux.cs.nctu.edu.tw "https://linux.cs.nctu.edu.tw") |
+    | 亚洲 · 国立阳明交通大学 · 台湾 :flag-TW: | [linux.cs.nycu.edu.tw](https://linux.cs.nycu.edu.tw "https://linux.cs.nycu.edu.tw") |
     | 亚洲 · 淡江大学 · 台湾 :flag-TW: | [ftp.tku.edu.tw](https://ftp.tku.edu.tw "https://ftp.tku.edu.tw") |
     | 亚洲 · Taiwan Digital Streaming · 台湾 :flag-TW: | [mirror.twds.com.tw](https://mirror.twds.com.tw "https://mirror.twds.com.tw") |
     | 亚洲 · AniGil Linux Archive · 韩国 :flag-KR: | [mirror.anigil.com](https://mirror.anigil.com "https://mirror.anigil.com") |

--- a/docs/mirrors/index.zh-Hant.md
+++ b/docs/mirrors/index.zh-Hant.md
@@ -68,7 +68,7 @@ search:
     | 亞洲 · xTom · 新加坡 :flag-SG: | [mirrors.xtom.sg](https://mirrors.xtom.sg "https://mirrors.xtom.sg") |
     | 亞洲 · 自由軟體實驗室(NCHC) · 臺灣 :flag-TW: | [free.nchc.org.tw](https://free.nchc.org.tw "https://free.nchc.org.tw") |
     | 亞洲 · OSS Planet · 臺灣 :flag-TW: | [mirror.ossplanet.net](https://mirror.ossplanet.net "https://mirror.ossplanet.net") |
-    | 亞洲 · 國立陽明交通大學 · 臺灣 :flag-TW: | [linux.cs.nctu.edu.tw](https://linux.cs.nctu.edu.tw "https://linux.cs.nctu.edu.tw") |
+    | 亞洲 · 國立陽明交通大學 · 臺灣 :flag-TW: | [linux.cs.nycu.edu.tw](https://linux.cs.nycu.edu.tw "https://linux.cs.nycu.edu.tw") |
     | 亞洲 · 淡江大學 · 臺灣 :flag-TW: | [ftp.tku.edu.tw](https://ftp.tku.edu.tw "https://ftp.tku.edu.tw") |
     | 亞洲 · Taiwan Digital Streaming · 臺灣 :flag-TW: | [mirror.twds.com.tw](https://mirror.twds.com.tw "https://mirror.twds.com.tw") |
     | 亞洲 · AniGil Linux Archive · 韓國 :flag-KR: | [mirror.anigil.com](https://mirror.anigil.com "https://mirror.anigil.com") |
@@ -166,7 +166,7 @@ search:
     | 亞洲 · xTom · 新加坡 :flag-SG: | [mirrors.xtom.sg](https://mirrors.xtom.sg "https://mirrors.xtom.sg") |
     | 亞洲 · 自由軟體實驗室(NCHC) · 臺灣 :flag-TW: | [free.nchc.org.tw](https://free.nchc.org.tw "https://free.nchc.org.tw") |
     | 亞洲 · OSS Planet · 臺灣 :flag-TW: | [mirror.ossplanet.net](https://mirror.ossplanet.net "https://mirror.ossplanet.net") |
-    | 亞洲 · 國立陽明交通大學 · 臺灣 :flag-TW: | [linux.cs.nctu.edu.tw](https://linux.cs.nctu.edu.tw "https://linux.cs.nctu.edu.tw") |
+    | 亞洲 · 國立陽明交通大學 · 臺灣 :flag-TW: | [linux.cs.nycu.edu.tw](https://linux.cs.nycu.edu.tw "https://linux.cs.nycu.edu.tw") |
     | 亞洲 · 淡江大學 · 臺灣 :flag-TW: | [ftp.tku.edu.tw](https://ftp.tku.edu.tw "https://ftp.tku.edu.tw") |
     | 亞洲 · Taiwan Digital Streaming · 臺灣 :flag-TW: | [mirror.twds.com.tw](https://mirror.twds.com.tw "https://mirror.twds.com.tw") |
     | 亞洲 · AniGil Linux Archive · 韓國 :flag-KR: | [mirror.anigil.com](https://mirror.anigil.com "https://mirror.anigil.com") |


### PR DESCRIPTION
Following the merger of National Chiao Tung University and National Yang-Ming University into NYCU, update the mirror URL accordingly.