### PR TITLE
fix(docs): replace the broken star-history chart embed

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -191,11 +191,11 @@ Copyright © 2026, [SuperManito](https://github.com/SuperManito). Released under
 
 This is a fully open-source project dedicated to providing convenience for computer professionals, making the process of switching software sources simpler.
 
-<a href="https://star-history.com/#SuperManito/LinuxMirrors&Date">
+<a href="https://afterglow.watch">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=SuperManito/LinuxMirrors&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=SuperManito/LinuxMirrors&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=SuperManito/LinuxMirrors&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://afterglow.watch/svg?repos=SuperManito/LinuxMirrors&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://afterglow.watch/svg?repos=SuperManito/LinuxMirrors&type=Date" />
+   <img alt="Star History Chart" src="https://afterglow.watch/svg?repos=SuperManito/LinuxMirrors&type=Date" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -191,11 +191,11 @@ Copyright © 2026, [SuperManito](https://github.com/SuperManito). Released under
 
 这是一个完全开源的项目，致力于为计算机从业者提供便利，使换源更简单
 
-<a href="https://star-history.com/#SuperManito/LinuxMirrors&Date">
+<a href="https://afterglow.watch">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=SuperManito/LinuxMirrors&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=SuperManito/LinuxMirrors&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=SuperManito/LinuxMirrors&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://afterglow.watch/svg?repos=SuperManito/LinuxMirrors&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://afterglow.watch/svg?repos=SuperManito/LinuxMirrors&type=Date" />
+   <img alt="Star History Chart" src="https://afterglow.watch/svg?repos=SuperManito/LinuxMirrors&type=Date" />
  </picture>
 </a>
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -191,11 +191,11 @@ Copyright © 2026, [SuperManito](https://github.com/SuperManito). Released under
 
 這是一個完全開源的專案，致力於為電腦從業者提供便利，使換源更簡單
 
-<a href="https://star-history.com/#SuperManito/LinuxMirrors&Date">
+<a href="https://afterglow.watch">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=SuperManito/LinuxMirrors&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=SuperManito/LinuxMirrors&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=SuperManito/LinuxMirrors&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://afterglow.watch/svg?repos=SuperManito/LinuxMirrors&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://afterglow.watch/svg?repos=SuperManito/LinuxMirrors&type=Date" />
+   <img alt="Star History Chart" src="https://afterglow.watch/svg?repos=SuperManito/LinuxMirrors&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star-history chart in the README has been a broken image since the end of June, when GitHub removed the stargazer endpoints and api.star-history.com stopped rendering.

This swaps the hostname to afterglow.watch in all three README copies, and points the link around the chart at afterglow.watch too, since the old anchor leads to the dead chart page. The chart URLs answer the same shape as before, drawn from daily snapshots of the public star count. I've been tracking LinuxMirrors since July 31, so the chart already carries history and fills in further every day.

Disclosure: I run afterglow.watch. It's free and there's no token, and I'm fixing these dead embeds where I find them. If you'd rather just delete the dead embed instead, that's a perfectly good fix too and I'm happy to close this pull request. You can also opt out of my tracking on the website.